### PR TITLE
Adding  Godot 4.6 dev version to the CI-PR workflow

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -51,6 +51,19 @@ jobs:
             godot-version: '4.5'
             godot-status: 'stable'
             dotnet-version: 'net9.0'
+          # Dev builds
+          # Latest
+          - version: 'latest'
+            godot-version: '4.6'
+            godot-status: 'dev4'
+          - version: 'latest'
+            godot-version: '4.6'
+            godot-status: 'dev4'
+            dotnet-version: 'net8.0'
+          - version: 'latest'
+            godot-version: '4.6'
+            godot-status: 'dev4'
+            dotnet-version: 'net9.0'
 
     permissions:
       actions: read


### PR DESCRIPTION
# What
Adding Godot 4.6.dev4 to ci-pr

