### PR TITLE
GD-118: Introduce security vulnerability issue template for CVE reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -1,0 +1,69 @@
+name: Security Vulnerability
+description: Report a security vulnerability or dependency CVE affecting gdUnit4-action
+title: "GD-XXX: Describe the vulnerability briefly"
+labels: ["security", "dependencies"]
+projects: ["projects/5"]
+assignees:
+  - MikeSchulze
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Reporting a security vulnerability
+        - Please search [open issues](https://github.com/godot-gdunit-labs/gdUnit4-action/issues?q=is%3Aissue) for duplicates before filing.
+        - For vulnerabilities in gdUnit4-action's own code that should **not** be disclosed publicly, use [GitHub Security Advisories](https://github.com/godot-gdunit-labs/gdUnit4-action/security/advisories/new) instead.
+
+  - type: input
+    id: cve-id
+    attributes:
+      label: CVE / GHSA Identifier
+      description: The CVE or GitHub Security Advisory ID for this vulnerability.
+      placeholder: "e.g. CVE-2026-1526 / GHSA-vrm6-8vpv-qv8q"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: CVSS severity rating as reported by the advisory.
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: input
+    id: affected-package
+    attributes:
+      label: Affected Package
+      description: The name of the vulnerable package (direct or transitive).
+      placeholder: "e.g. undici"
+    validations:
+      required: true
+
+  - type: input
+    id: affected-version
+    attributes:
+      label: Installed Version
+      description: The vulnerable version currently resolved in this project.
+      placeholder: "e.g. 5.29.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Vulnerability Description
+      description: |
+        A brief description of the vulnerability and its impact.
+        Include a link to the original advisory or Dependabot alert.
+      placeholder: |
+        Describe what the vulnerability allows an attacker to do and under what conditions.
+
+        Advisory / Dependabot Alert: https://...
+    validations:
+      required: true


### PR DESCRIPTION
# Why
No existing issue template fits security vulnerability reports such as Dependabot CVE alerts, so they get shoehorned into the Bug Report template which asks for Godot version, OS, and reproduction steps — all irrelevant to a dependency CVE.

# What
- Add `.github/ISSUE_TEMPLATE/security_vulnerability.yml` with fields for CVE/GHSA ID, severity, affected package, installed version, first patched version, vulnerability description, and advisory URL

Closes #118