### PR TITLE
GD-120: Upgrade `@actions/core` to resolve high-severity undici DoS vulnerability

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -1,0 +1,69 @@
+name: Security Vulnerability
+description: Report a security vulnerability or dependency CVE affecting gdUnit4-action
+title: "GD-XXX: Describe the vulnerability briefly"
+labels: ["security", "dependencies"]
+projects: ["projects/5"]
+assignees:
+  - MikeSchulze
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Reporting a security vulnerability
+        - Please search [open issues](https://github.com/godot-gdunit-labs/gdUnit4-action/issues?q=is%3Aissue) for duplicates before filing.
+        - For vulnerabilities in gdUnit4-action's own code that should **not** be disclosed publicly, use [GitHub Security Advisories](https://github.com/godot-gdunit-labs/gdUnit4-action/security/advisories/new) instead.
+
+  - type: input
+    id: cve-id
+    attributes:
+      label: CVE / GHSA Identifier
+      description: The CVE or GitHub Security Advisory ID for this vulnerability.
+      placeholder: "e.g. CVE-2026-1526 / GHSA-vrm6-8vpv-qv8q"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: CVSS severity rating as reported by the advisory.
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: input
+    id: affected-package
+    attributes:
+      label: Affected Package
+      description: The name of the vulnerable package (direct or transitive).
+      placeholder: "e.g. undici"
+    validations:
+      required: true
+
+  - type: input
+    id: affected-version
+    attributes:
+      label: Installed Version
+      description: The vulnerable version currently resolved in this project.
+      placeholder: "e.g. 5.29.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Vulnerability Description
+      description: |
+        A brief description of the vulnerability and its impact.
+        Include a link to the original advisory or Dependabot alert.
+      placeholder: |
+        Describe what the vulnerability allows an attacker to do and under what conditions.
+
+        Advisory / Dependabot Alert: https://...
+    validations:
+      required: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,47 +8,39 @@
       "name": "gdunit4-action",
       "version": "1.0.0",
       "dependencies": {
-        "@actions/core": "^1.11.1"
+        "@actions/core": "^3.0.1"
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
       "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "dependencies": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^3.0.2"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
-      }
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -59,15 +51,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "private": true,
   "dependencies": {
-    "@actions/core": "^1.11.1"
+    "@actions/core": "^3.0.1"
   }
 }


### PR DESCRIPTION
# Why
Undici 5.29.0 (transitive via `@actions/core`) is vulnerable to a decompression bomb DoS attack (CVE-2026-1526, high severity), with no workaround available.

# What
Upgrades `@actions/core` to 3.0.1, which transitively resolves `undici` to 6.27.0, the patched version.

Closes #120