### PR TITLE
GD-123: Enable automated `npm` dependency updates via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
# Why
Dependabot could raise `npm` vulnerability alerts but not auto-fix them, as the `npm` ecosystem was missing from its configuration.

# What
- Adds `npm` to `dependabot.yml` with a weekly schedule so Dependabot can open update PRs automatically

Closes #123